### PR TITLE
Add  setup command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We recommend using [virtualenv](http://virtualenv.readthedocs.org/en/latest/virt
 Once you have virtualenvwrapper set up,
 
 ```bash
-mkvirtualenv nyc-councilmatic
+mkvirtualenv nyc-councilmatic --python=`which python3`
 git clone https://github.com/datamade/nyc-councilmatic.git
 cd nyc-councilmatic
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ python manage.py loaddata
 ## Running NYC Councilmatic locally
 
 ``` bash
+python manage.py collectstatic
 python manage.py runserver
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ python manage.py loaddata
 ## Running NYC Councilmatic locally
 
 ``` bash
+python manage.py createcachetable
 python manage.py collectstatic
 python manage.py runserver
 ```

--- a/councilmatic/settings_deployment.py.example
+++ b/councilmatic/settings_deployment.py.example
@@ -7,8 +7,8 @@ SECRET_KEY = 'replacethiswithsomethingsecret'
 TIME_ZONE = 'US/Eastern'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-# Set this to True while you are developing
-DEBUG = False
+# Set this to False while you are in production
+DEBUG = True
 
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases


### PR DESCRIPTION
When trying to get through setup, there was no /static directory in the root path, but that directory was in the gitignore. Figured this needed to be run first.
